### PR TITLE
Fix username_to_userid (#1447)

### DIFF
--- a/errbot/backends/base.py
+++ b/errbot/backends/base.py
@@ -220,6 +220,10 @@ class UserDoesNotExistError(Exception):
     """Exception that is raised when performing an operation
     on a user that doesn't exist"""
 
+class UserNotUniqueError(Exception):
+    """
+    Exception raised to report a user has not been uniquely identified on the chat service.
+    """
 
 class Message(object):
     """

--- a/errbot/backends/slack_rtm.py
+++ b/errbot/backends/slack_rtm.py
@@ -13,8 +13,10 @@ from markdown import Markdown
 from markdown.extensions.extra import ExtraExtension
 from markdown.preprocessors import Preprocessor
 
-from errbot.backends.base import Identifier, Message, Presence, ONLINE, AWAY, Room, RoomError, RoomDoesNotExistError, \
-    UserDoesNotExistError, RoomOccupant, Person, Card, Stream
+from errbot.backends.base import (
+    Identifier, Message, Presence, ONLINE, AWAY, Room, RoomError, RoomDoesNotExistError,
+    UserDoesNotExistError, UserNotUniqueError, RoomOccupant, Person, Card, Stream
+)
 from errbot.core import ErrBot
 from errbot.utils import split_string_after
 from errbot.rendering.ansiext import AnsiExtension, enable_format, IMTEXT_CHRS
@@ -518,22 +520,28 @@ class SlackRTMBackend(ErrBot):
         if user == self.bot_identifier:
             self.callback_room_joined(SlackRoom(webclient=webclient, channelid=event['channel'], bot=self))
 
-    @staticmethod
-    def userid_to_username(webclient: WebClient, id_: str):
+    def userid_to_username(self, id_: str):
         """Convert a Slack user ID to their user name"""
-        user = webclient.users_info(user=id_)['user']
+        user = self.webclient.users_info(user=id_)['user']
         if user is None:
             raise UserDoesNotExistError(f'Cannot find user with ID {id_}.')
         return user['name']
 
-    @staticmethod
-    def username_to_userid(name: str):
+    def username_to_userid(self, name: str):
         """Convert a Slack user name to their user ID"""
         name = name.lstrip('@')
-        user = [user for user in self.webclient.users_list()['users'] if user['name'] == name]
-        if user is None:
+        user = [user for user in self.webclient.users_list()['members'] if user['name'] == name]
+        if user == []:
             raise UserDoesNotExistError(f'Cannot find user {name}.')
-        return user['id']
+        if len(user) > 1:
+            log.error(
+                "Failed to uniquely identify '{}'.  Errbot found the following users: {}".format(
+                    name,
+                    " ".join(["{}={}".format(u['name'], u['id']) for u in user])
+                )
+            )
+            raise UserNotUniqueError(f"Failed to uniquely identify {name}.")
+        return user[0]['id']
 
     def channelid_to_channelname(self, id_: str):
         """Convert a Slack channel ID to its channel name"""


### PR DESCRIPTION
This PR fixes username_to_userid method.  It also adds an exception when the username not uniquely identified since this constitutes a security risk or leaks communication to an incorrect party.